### PR TITLE
Generate interactive organigram chart

### DIFF
--- a/iwb_organigram_fixed.json
+++ b/iwb_organigram_fixed.json
@@ -1,0 +1,1226 @@
+{
+  "$schema": "https://vega.github.io/schema/vega/v5.json",
+  "description": "Organigram IWB",
+  "width": { "signal": "2500" },
+  "height": { "signal": "1800" },
+  "background": null,
+  "autosize": "pad",
+  "padding": 50,
+  "signals": [
+    { "name": "nodeWidth", "value": 300 },
+    { "name": "nodeHeight", "value": 70 },
+    { "name": "verticalNodeGap", "value": 350 },
+    { "name": "horizontalNodeGap", "value": -150 },
+    { "name": "rpExtraGap", "value": 10},
+    { "name": "countryChildrenExtraGap", "value": 1.25 },
+    { "name": "countryChildHeightFactor", "value": 1.0 },
+    { "name": "countryLinkYOffset", "value": 25 },
+    {
+      "name": "startingDepth",
+      "value": 2,
+      "on": [
+        {
+          "events": { "type": "timer", "throttle": 0 },
+          "update": "-1"
+        }
+      ]
+    },
+    { "name": "stackStep", "update": "nodeHeight + verticalNodeGap" },
+    { "name": "rowOffset", "value": 0.066 },
+    {
+      "name": "node",
+      "value": 0,
+      "on": [
+        {
+          "events": { "type": "click", "markname": "node" },
+          "update": "datum.id"
+        },
+        {
+          "events": { "type": "timer", "throttle": 10 },
+          "update": "0"
+        }
+      ]
+    },
+    {
+      "name": "nodeHighlight",
+      "value": "[0]",
+      "on": [
+        {
+          "events": { "type": "mouseover", "markname": "node" },
+          "update": "pluck(treeAncestors('treeCalcs', datum.id), 'id')"
+        },
+        {
+          "events": { "type": "mouseout" },
+          "update": "[0]"
+        }
+      ]
+    },
+    {
+      "name": "isExpanded",
+      "value": 0,
+      "on": [
+        {
+          "events": { "type": "click", "markname": "node" },
+          "update": "datum.children > 0 && indata('treeClickStorePerm', 'id', datum.childrenIds[0])?true:false"
+        }
+      ]
+    },
+    { "name": "xrange", "update": "[0, width]" },
+    { "name": "yrange", "update": "[0, height]" },
+    {
+      "name": "down",
+      "value": null,
+      "on": [
+        { "events": "touchend", "update": "null" },
+        { "events": "mousedown, touchstart", "update": "xy()" }
+      ]
+    },
+    {
+      "name": "xcur",
+      "value": null,
+      "on": [
+        {
+          "events": "mousedown, touchstart, touchend",
+          "update": "slice(xdom)"
+        }
+      ]
+    },
+    {
+      "name": "ycur",
+      "value": null,
+      "on": [
+        {
+          "events": "mousedown, touchstart, touchend",
+          "update": "slice(ydom)"
+        }
+      ]
+    },
+    {
+      "name": "delta",
+      "value": [0, 0],
+      "on": [
+        {
+          "events": [
+            {
+              "source": "window",
+              "type": "mousemove",
+              "consume": true,
+              "between": [
+                { "type": "mousedown" },
+                { "source": "window", "type": "mouseup" }
+              ]
+            },
+            {
+              "type": "touchmove",
+              "consume": true,
+              "filter": "event.touches.length === 1"
+            }
+          ],
+          "update": "down ? [down[0]-x(), down[1]-y()] : [0,0]"
+        }
+      ]
+    },
+    {
+      "name": "anchor",
+      "value": [0, 0],
+      "on": [
+        {
+          "events": "wheel",
+          "update": "[invert('xscale', x()), invert('yscale', y())]"
+        },
+        {
+          "events": {
+            "type": "touchstart",
+            "filter": "event.touches.length===2"
+          },
+          "update": "[(xdom[0] + xdom[1]) / 2, (ydom[0] + ydom[1]) / 2]"
+        }
+      ]
+    },
+    { "name": "xext", "update": "[0,width]" },
+    { "name": "yext", "update": "[0,height]" },
+    {
+      "name": "zoom",
+      "value": 1,
+      "on": [
+        {
+          "events": "wheel!",
+          "force": true,
+          "update": "pow(1.001, event.deltaY * pow(16, event.deltaMode))"
+        },
+        {
+          "events": { "signal": "dist2" },
+          "force": true,
+          "update": "dist1 / dist2"
+        }
+      ]
+    },
+    {
+      "name": "dist1",
+      "value": 0,
+      "on": [
+        {
+          "events": {
+            "type": "touchstart",
+            "filter": "event.touches.length===2"
+          },
+          "update": "pinchDistance(event)"
+        },
+        {
+          "events": { "signal": "dist2" },
+          "update": "dist2"
+        }
+      ]
+    },
+    {
+      "name": "dist2",
+      "value": 0,
+      "on": [
+        {
+          "events": {
+            "type": "touchmove",
+            "consume": true,
+            "filter": "event.touches.length===2"
+          },
+          "update": "pinchDistance(event)"
+        }
+      ]
+    },
+    {
+      "name": "xdom",
+      "update": "slice(xext)",
+      "on": [
+        {
+          "events": { "signal": "delta" },
+          "update": "[xcur[0] + span(xcur) * delta[0] / width, xcur[1] + span(xcur) * delta[0] / width]"
+        },
+        {
+          "events": { "signal": "zoom" },
+          "update": "[anchor[0] + (xdom[0] - anchor[0]) * zoom, anchor[0] + (xdom[1] - anchor[0]) * zoom]"
+        },
+        { "events": "dblclick", "update": "[0,width]" }
+      ]
+    },
+    {
+      "name": "ydom",
+      "update": "slice(yext)",
+      "on": [
+        {
+          "events": { "signal": "delta" },
+          "update": "[ycur[0] + span(ycur) * delta[1] / height, ycur[1] + span(ycur) * delta[1] / height]"
+        },
+        {
+          "events": { "signal": "zoom" },
+          "update": "[anchor[1] + (ydom[0] - anchor[1]) * zoom, anchor[1] + (ydom[1] - anchor[1]) * zoom]"
+        },
+        { "events": "dblclick", "update": "[0,height]" }
+      ]
+    },
+    {
+      "name": "scaledNodeWidth",
+      "update": "(nodeWidth/ span(xdom))*width"
+    },
+    {
+      "name": "scaledNodeHeight",
+      "update": "abs(nodeHeight/ span(ydom))*height"
+    },
+    { "name": "scaledFont13", "update": "(22/ span(xdom))*width" },
+    { "name": "scaledFont12", "update": "(15/ span(xdom))*width" },
+    { "name": "scaledFont11", "update": "(14/ span(xdom))*width" },
+    { "name": "scaledKPIHeight", "update": "(5/ span(xdom))*width" },
+    { "name": "scaledLimit", "update": "(20/ span(xdom))*width" },
+    { "name": "iwbShiftX", "value": 400 },
+    {
+      "name": "sideNodes",
+      "value": [
+        "Mutsee AlpinSolar AG",
+        "Kraftwerke Oberhasli AG",
+        "PV-Anlagen Oberaar und Räterichsboden",
+        "Windpark Große Schanze GmbH & Co. KG"
+      ]
+    },
+    {
+      "name": "isLänderholding",
+      "value": false,
+      "on": [
+        {
+          "events": { "type": "mouseover", "markname": "node" },
+          "update": "indexof(datum.title_lower, 'iwb renewable power ag') >= 0"
+        },
+        {
+          "events": { "type": "mouseout" },
+          "update": "false"
+        }
+      ]
+    }
+  ],
+  "data": [
+    { "name": "dataset" },
+    {
+      "name": "wideToTallBase",
+      "source": "dataset",
+      "transform": [
+        {
+          "type": "formula",
+          "expr": "{key: datum['level1'], parent: null, person: datum['person'], kpi: datum['kpi'], LevelId: 1}",
+          "as": "l1"
+        },
+        {
+          "type": "formula",
+          "expr": "{key: datum['level1'] + '|' + datum['level2'], parent: datum['level1'], person: datum['person'], kpi: datum['kpi'], LevelId: 2}",
+          "as": "l2"
+        },
+        {
+          "type": "formula",
+          "expr": "{key: datum['level1'] + '|' + datum['level2'] + '|' + datum['level3'], parent: datum['level1'] + '|' + datum['level2'], person: datum['person'], kpi: datum['kpi'], LevelId: 3}",
+          "as": "l3"
+        },
+        {
+          "type": "formula",
+          "expr": "{key: datum['level1'] + '|' + datum['level2'] + '|' + datum['level3'] + '|' + datum['level4'], parent: datum['level1'] + '|' + datum['level2'] + '|' + datum['level3'], person: datum['person'], kpi: datum['kpi'], LevelId: 4}",
+          "as": "l4"
+        },
+        {
+          "type": "formula",
+          "expr": "{key: datum['level1'] + '|' + datum['level2'] + '|' + datum['level3'] + '|' + datum['level4'] + '|' + datum['level5'], parent: datum['level1'] + '|' + datum['level2'] + '|' + datum['level3'] + '|' + datum['level4'], person: datum['person'], kpi: datum['kpi'], LevelId: 5}",
+          "as": "l5"
+        },
+        {
+          "type": "formula",
+          "expr": "{key: datum['level1'] + '|' + datum['level2'] + '|' + datum['level3'] + '|' + datum['level4'] + '|' + datum['level5'] + '|' + datum['level6'], parent: datum['level1'] + '|' + datum['level2'] + '|' + datum['level3'] + '|' + datum['level4'] + '|' + datum['level5'], person: datum['person'], kpi: datum['kpi'], LevelId: 6}",
+          "as": "l6"
+        },
+        {
+          "type": "fold",
+          "fields": ["l1", "l2", "l3", "l4", "l5", "l6"]
+        },
+        { "type": "project", "fields": ["key", "value"] },
+        { "type": "formula", "expr": "datum.value.key", "as": "id" },
+        {
+          "type": "formula",
+          "expr": "reverse(split(datum.value.key,'|'))[0]",
+          "as": "title"
+        },
+        { "type": "formula", "expr": "datum.value.parent", "as": "parent" },
+        { "type": "formula", "expr": "datum['level2']", "as": "LevelId" },
+        {
+          "type": "filter",
+          "expr": "datum.title != 'null' && datum.title != 'undefined'"
+        },
+        {
+          "type": "aggregate",
+          "groupby": ["id", "parent", "title", "value"]
+        },
+        { "type": "formula", "expr": "datum.value.person", "as": "person" },
+        { "type": "formula", "expr": "datum.value.kpi", "as": "kpi" },
+        { "type": "formula", "expr": "datum.value.LevelId", "as": "LevelId" }
+      ]
+    },
+    {
+      "name": "wideToTall",
+      "source": "wideToTallBase",
+      "transform": [{ "type": "filter", "expr": "datum.LevelId <= 6" }]
+    },
+    {
+      "name": "treeCalcs",
+      "source": "wideToTall",
+      "transform": [
+        {
+          "type": "stratify",
+          "key": "id",
+          "parentKey": "parent"
+        },
+        {
+          "type": "tree",
+          "method": { "signal": "'tidy'" },
+          "separation": { "signal": "false" },
+          "as": ["y", "x", "depth", "children"]
+        },
+        {
+          "as": "parent",
+          "type": "formula",
+          "expr": "datum.parent"
+        }
+      ]
+    },
+    {
+      "name": "treeHead",
+      "source": "treeCalcs",
+      "transform": [{ "type": "filter", "expr": "datum.depth < 2" }]
+    },
+    {
+      "name": "treeRow",
+      "source": "treeCalcs",
+      "transform": [
+        {
+          "type": "filter",
+          "expr": "datum.depth >= 2"
+        },
+        {
+          "type": "lookup",
+          "from": "treeCalcs",
+          "key": "id",
+          "fields": ["parent"],
+          "values": ["x", "y", "depth"],
+          "as": ["parent_x", "parent_y", "parent_depth"],
+          "default": "null"
+        },
+        {
+          "type": "window",
+          "sort": { "field": "id", "order": "ascending" },
+          "ops": ["dense_rank"],
+          "fields": ["id"],
+          "groupby": ["parent"],
+          "as": ["d_rank"]
+        },
+        {
+          "type": "formula",
+          "expr": "lower(trim(reverse(split(datum.parent,'|'))[0]))",
+          "as": "parent_title_lower"
+        },
+        {
+          "type": "formula",
+          "expr": "lower(trim(reverse(split(datum.id,'|'))[0]))",
+          "as": "id_title_lower"
+        },
+        {
+          "type": "formula",
+          "expr": "((datum.depth >= 3 && (indexof(datum.parent_title_lower,'iwb energie deutschland')>=0 || indexof(datum.parent_title_lower,'iwb energie france')>=0 || indexof(datum.parent_title_lower,'iwb energie schweiz')>=0)) || indexof(datum.id_title_lower,'juvent sa')>=0 || indexof(datum.id_title_lower,'swisspower green gas')>=0) && indexof(datum.id_title_lower,'windpark grosse schanze')==-1",
+          "as": "stackMe"
+        },
+        { "type": "formula", "expr": "datum.x", "as": "x" },
+        { "type": "formula", "expr": "datum.y", "as": "y" },
+        {
+          "type": "formula",
+          "expr": "scale('xscale', datum.x)",
+          "as": "xscaled"
+        },
+        {
+          "type": "formula",
+          "expr": "scale('yscale', datum.y)",
+          "as": "yscaled"
+        }
+      ]
+    },
+    {
+      "name": "treeChildren",
+      "source": "treeCalcs",
+      "transform": [
+        {
+          "type": "aggregate",
+          "groupby": ["parent"],
+          "fields": ["parent"],
+          "ops": ["values"],
+          "as": ["childrenObjects"]
+        },
+        {
+          "type": "formula",
+          "expr": "pluck(datum.childrenObjects,'id')",
+          "as": "childrenIds"
+        }
+      ]
+    },
+    {
+      "name": "treeAncestors",
+      "source": "treeCalcs",
+      "transform": [
+        {
+          "type": "formula",
+          "as": "treeAncestors",
+          "expr": "treeAncestors('treeCalcs', datum.id, 'root')"
+        },
+        {
+          "type": "flatten",
+          "fields": ["treeAncestors"]
+        },
+        {
+          "type": "formula",
+          "expr": "datum.treeAncestors.parent",
+          "as": "allParents"
+        }
+      ]
+    },
+    {
+      "name": "treeChildrenAll",
+      "source": "treeAncestors",
+      "transform": [
+        {
+          "type": "project",
+          "fields": [
+            "allParents",
+            "id",
+            "name",
+            "parent",
+            "x",
+            "y",
+            "depth",
+            "children"
+          ]
+        },
+        {
+          "type": "aggregate",
+          "fields": ["parent", "parent", "id"],
+          "ops": ["values", "count", "min"],
+          "groupby": ["allParents"],
+          "as": ["allChildrenObjects", "allChildrenCount", "id"]
+        },
+        {
+          "type": "formula",
+          "expr": "pluck(datum.allChildrenObjects,'id')",
+          "as": "allChildrenIds"
+        }
+      ]
+    },
+    {
+      "name": "treeClickStoreTemp",
+      "source": "treeAncestors",
+      "transform": [
+        {
+          "type": "filter",
+          "expr": "startingDepth!=-1 ? datum.depth <= startingDepth : node != 0 && !isExpanded ? (datum.parent == node || datum.id == node) : node != 0 && isExpanded ? datum.allParents == node : false"
+        },
+        {
+          "type": "project",
+          "fields": ["id", "name", "parent", "x", "y", "depth", "children"]
+        },
+        {
+          "type": "aggregate",
+          "fields": ["id"],
+          "ops": ["min"],
+          "groupby": ["id", "name", "parent", "x", "y", "depth", "children"]
+        }
+      ]
+    },
+    {
+      "name": "treeClickStorePerm",
+      "values": [],
+      "on": [
+        {
+          "trigger": "startingDepth>=0",
+          "insert": "data('treeClickStoreTemp')"
+        },
+        {
+          "trigger": "node",
+          "insert": "!isExpanded? data('treeClickStoreTemp'):false"
+        },
+        {
+          "trigger": "node",
+          "remove": "isExpanded?data('treeClickStoreTemp'):false"
+        }
+      ]
+    },
+    {
+      "name": "treeLayout",
+      "source": ["treeHead", "treeRow"],
+      "transform": [
+        {
+          "type": "filter",
+          "expr": "indata('treeClickStorePerm','id', datum.id)"
+        },
+        {
+          "type": "filter",
+          "expr": "!datum.stackMe"
+        },
+        {
+          "type": "filter",
+          "expr": "indexof(sideNodes, reverse(split(datum.id,'|'))[0]) == -1"
+        },
+        {
+          "type": "formula",
+          "expr": "datum.isLänderholding ? datum.parent_x - 300 : datum.parent_x",
+          "as": "x"
+        },
+        {
+          "type": "formula",
+          "expr": "lower(trim(reverse(split(datum.id,'|'))[0]))",
+          "as": "title_lower"
+        },
+        {
+          "type": "formula",
+          "expr": "indexof(datum.title_lower,'iwb energie france')>=0 ? 0 : indexof(datum.title_lower,'iwb energie deutschland')>=0 ? 1 : indexof(datum.title_lower,'iwb energie schweiz')>=0 ? 2 : 99",
+          "as": "orderHint"
+        },
+        {
+          "type": "collect",
+          "sort": {
+            "field": ["parent", "orderHint", "id"],
+            "order": ["ascending", "ascending", "ascending"]
+          }
+        },
+        {
+          "type": "stratify",
+          "key": "id",
+          "parentKey": "parent"
+        },
+        {
+          "type": "tree",
+          "method": { "signal": "'tidy'" },
+          "nodeSize": [
+            { "signal": "nodeHeight+verticalNodeGap" },
+            { "signal": "nodeWidth+horizontalNodeGap" }
+          ],
+          "separation": { "signal": "false" },
+          "as": ["x", "y", "depth", "children"]
+        },
+        {
+          "type": "formula",
+          "expr": "datum.title == 'IWB Renewable Power AG' ? datum.x - 137 : datum.x",
+          "as": "x"
+        },
+        {
+          "type": "formula",
+          "expr": "lower(trim(reverse(split(datum.parent,'|'))[0]))",
+          "as": "parent_title_lower"
+        },
+        {
+          "type": "formula",
+          "expr": "datum.y + (indexof(datum.parent_title_lower,'iwb renewable power ag')>=0 ? rpExtraGap : 0) + ((indexof(datum.parent_title_lower,'iwb energie france')>=0 || indexof(datum.parent_title_lower,'iwb energie deutschland')>=0) ? countryChildrenExtraGap : 0)",
+          "as": "y"
+        },
+        {
+          "type": "formula",
+          "expr": "scale('xscale',datum.x)",
+          "as": "xscaled"
+        },
+        {
+          "type": "formula",
+          "expr": "scale('yscale', datum.y)",
+          "as": "yscaled"
+        },
+        {
+          "as": "parent",
+          "type": "formula",
+          "expr": "datum.parent"
+        }
+      ]
+    },
+    {
+      "name": "countriesBox",
+      "source": "treeLayout",
+      "transform": [
+        {
+          "type": "formula",
+          "expr": "lower(trim(reverse(split(datum.parent,'|'))[0]))",
+          "as": "parent_title_lower"
+        },
+        {
+          "type": "formula",
+          "expr": "lower(trim(reverse(split(datum.id,'|'))[0]))",
+          "as": "id_title_lower"
+        },
+        {
+          "type": "filter",
+          "expr": "indexof(datum.parent_title_lower,'iwb renewable power ag')>=0"
+        },
+        {
+          "type": "filter",
+          "expr": "indexof(datum.id_title_lower,'iwb energie france')>=0 || indexof(datum.id_title_lower,'iwb energie deutschland')>=0 || indexof(datum.id_title_lower,'iwb energie schweiz')>=0"
+        },
+        {
+          "type": "aggregate",
+          "fields": ["x", "x", "y", "y"],
+          "ops": ["min", "max", "min", "max"],
+          "as": ["minx", "maxx", "miny", "maxy"]
+        },
+        {
+          "type": "formula",
+          "expr": "datum.minx - 20",
+          "as": "bx"
+        },
+        {
+          "type": "formula",
+          "expr": "datum.miny - 30",
+          "as": "by"
+        },
+        {
+          "type": "formula",
+          "expr": "datum.maxx - datum.minx + 300",
+          "as": "bw"
+        },
+        {
+          "type": "formula",
+          "expr": "datum.maxy - datum.miny + 100",
+          "as": "bh"
+        },
+        {
+          "type": "formula",
+          "expr": "scale('xscale', datum.bx)",
+          "as": "bxs"
+        },
+        {
+          "type": "formula",
+          "expr": "scale('yscale', datum.by)",
+          "as": "bys"
+        },
+        {
+          "type": "formula",
+          "expr": "scale('xscale', datum.bx+datum.bw)-scale('xscale', datum.bx)",
+          "as": "bws"
+        },
+        {
+          "type": "formula",
+          "expr": "scale('yscale', datum.by+datum.bh)-scale('yscale', datum.by)",
+          "as": "bhs"
+        }
+      ]
+    },
+    {
+      "name": "treeLayoutAdjusted",
+      "source": "treeRow",
+      "transform": [
+        {
+          "type": "filter",
+          "expr": "datum.stackMe"
+        },
+        {
+          "type": "lookup",
+          "from": "treeLayout",
+          "key": "id",
+          "fields": ["parent"],
+          "values": ["x", "y"],
+          "as": ["parent_x", "parent_y"],
+          "default": "null"
+        },
+        {
+          "type": "window",
+          "sort": { "field": "id", "order": "ascending" },
+          "ops": ["dense_rank"],
+          "fields": ["id"],
+          "groupby": ["parent"],
+          "as": ["d_rank"]
+        },
+        {
+          "type": "formula",
+          "as": "x",
+          "expr": "( (indexof(datum.id_title_lower,'juvent sa')>=0 || indexof(datum.id_title_lower,'swisspower green gas')>=0) ? datum.parent_x + nodeWidth + 600 : datum.parent_x ) + ( ( (indexof(datum.parent_title_lower,'iwb energie france')>=0 || indexof(datum.parent_title_lower,'iwb energie deutschland')>=0 || indexof(datum.parent_title_lower,'iwb energie schweiz')>=0) ? nodeWidth*countryChildrenExtraGap : nodeWidth ) - nodeWidth )/2"
+        },
+        {
+          "type": "formula",
+          "expr": "datum.parent_y + nodeHeight + (datum.d_rank + 1) * (nodeHeight + 8)",
+          "as": "y"
+        },
+        {
+          "type": "formula",
+          "expr": "scale('xscale', datum.x)",
+          "as": "xscaled"
+        },
+        {
+          "type": "formula",
+          "expr": "scale('yscale', datum.y)",
+          "as": "yscaled"
+        }
+      ]
+    },
+    {
+      "name": "treeLayoutSide",
+      "source": "treeCalcs",
+      "transform": [
+        {
+          "type": "filter",
+          "expr": "indexof(sideNodes, reverse(split(datum.id,'|'))[0]) > -1"
+        },
+        {
+          "type": "lookup",
+          "from": "treeLayout",
+          "key": "id",
+          "fields": ["parent"],
+          "values": ["x", "y"],
+          "as": ["parent_x_raw", "parent_y_raw"],
+          "default": null
+        },
+        {
+          "type": "lookup",
+          "from": "treeLayoutAdjusted",
+          "key": "id",
+          "fields": ["parent"],
+          "values": ["x", "y"],
+          "as": ["parent_x_adj", "parent_y_adj"],
+          "default": null
+        },
+        {
+          "type": "formula",
+          "expr": "isValid(datum.parent_x_raw) ? datum.parent_x_raw : datum.parent_x_adj",
+          "as": "parent_x"
+        },
+        {
+          "type": "formula",
+          "expr": "isValid(datum.parent_y_raw) ? datum.parent_y_raw : datum.parent_y_adj",
+          "as": "parent_y"
+        },
+        {
+          "type": "filter",
+          "expr": "isValid(datum.parent_x) && isValid(datum.parent_y)"
+        },
+        {
+          "type": "window",
+          "sort": { "field": "id", "order": "ascending" },
+          "ops": ["dense_rank"],
+          "fields": ["id"],
+          "groupby": ["parent"],
+          "as": ["d_rank"]
+        },
+        {
+          "type": "formula",
+          "expr": "datum.parent_x + nodeWidth + 450",
+          "as": "x"
+        },
+        {
+          "type": "formula",
+          "expr": "datum.parent_y +100 + (datum.d_rank - 1) * (nodeHeight + 8)",
+          "as": "y"
+        },
+        {
+          "type": "formula",
+          "expr": "scale('xscale', datum.x)",
+          "as": "xscaled"
+        },
+        {
+          "type": "formula",
+          "expr": "scale('yscale', datum.y)",
+          "as": "yscaled"
+        },
+        {
+          "as": "parent",
+          "type": "formula",
+          "expr": "datum.parent"
+        }
+      ]
+    },
+    {
+      "name": "AdjustedSide",
+      "source": "treeLayoutSide",
+      "transform": [
+        {
+          "type": "nest",
+          "keys": ["id", "parent"],
+          "generate": true
+        }
+      ]
+    },
+    {
+      "name": "linksSide",
+      "source": "AdjustedSide",
+      "transform": [
+        {
+          "type": "treelinks"
+        },
+        {
+          "type": "linkpath",
+          "orient": "horizontal",
+          "shape": "diagonal",
+          "sourceY": {
+            "expr": "scale('yscale', datum.target.parent_y + nodeHeight/2 + ((indexof(lower(trim(reverse(split(datum.target.parent,'|'))[0])),'iwb energie france')>=0 || indexof(lower(trim(reverse(split(datum.target.parent,'|'))[0])),'iwb energie deutschland')>=0 || indexof(lower(trim(reverse(split(datum.target.parent,'|'))[0])),'iwb energie schweiz')>=0) ? countryLinkYOffset : 0))"
+          },
+          "sourceX": {
+            "expr": "scale('xscale', datum.target.parent_x + nodeWidth/2)"
+          },
+          "targetY": {
+            "expr": "scale('yscale', datum.target.y + nodeHeight/2)"
+          },
+          "targetX": {
+            "expr": "scale('xscale', datum.target.x + nodeWidth/2)"
+          }
+        },
+        {
+          "type": "filter",
+          "expr": "indata('treeClickStorePerm', 'id', datum.target.id)"
+        }
+      ]
+    },
+    {
+      "name": "fullTreeLayout",
+      "source": ["treeLayout", "treeLayoutAdjusted", "treeLayoutSide"],
+      "transform": [
+        {
+          "type": "lookup",
+          "from": "treeChildren",
+          "key": "parent",
+          "fields": ["id"],
+          "values": ["childrenObjects", "childrenIds"]
+        },
+        {
+          "type": "lookup",
+          "from": "treeChildrenAll",
+          "key": "allParents",
+          "fields": ["id"],
+          "values": ["allChildrenIds", "allChildrenObjects"]
+        },
+        {
+          "type": "lookup",
+          "from": "treeCalcs",
+          "key": "id",
+          "fields": ["id"],
+          "values": ["children"]
+        },
+        {
+          "type": "formula",
+          "expr": "reverse(pluck(treeAncestors('treeCalcs', datum.id), 'id'))[1]",
+          "as": "treeParent"
+        }
+      ]
+    },
+    {
+      "name": "visibleNodes",
+      "source": "fullTreeLayout",
+      "transform": [
+        {
+          "type": "filter",
+          "expr": "indata('treeClickStorePerm', 'id', datum.id)"
+        }
+      ]
+    },
+    {
+      "name": "maxWidthAndHeight",
+      "source": "visibleNodes",
+      "transform": [
+        {
+          "type": "aggregate",
+          "groupby": ["depth"],
+          "fields": ["depth", "x", "y"],
+          "ops": ["count", "max", "max"],
+          "as": ["count", "x", "y"]
+        },
+        {
+          "type": "aggregate",
+          "fields": ["depth", "count", "x", "y"],
+          "ops": ["max", "max", "max", "max"],
+          "as": ["maxDepth", "maxNodes", "maxX", "maxY"]
+        }
+      ]
+    },
+    {
+      "name": "links",
+      "source": "treeLayout",
+      "transform": [
+        {
+          "type": "treelinks"
+        },
+        {
+          "type": "linkpath",
+          "orient": "horizontal",
+          "shape": "diagonal",
+          "sourceY": {
+            "expr": "scale('yscale', datum.source.y + nodeHeight/2 + ((indexof(datum.source.title_lower,'iwb energie france')>=0 || indexof(datum.source.title_lower,'iwb energie deutschland')>=0 || indexof(datum.source.title_lower,'iwb energie schweiz')>=0) ? countryLinkYOffset : 0))"
+          },
+          "sourceX": {
+            "expr": "scale('xscale', datum.source.x + nodeWidth/2)"
+          },
+          "targetY": {
+            "expr": "scale('yscale', datum.target.y + nodeHeight/2)"
+          },
+          "targetX": {
+            "expr": "scale('xscale', datum.target.x + nodeWidth/2)"
+          }
+        },
+        {
+          "type": "filter",
+          "expr": " indata('treeClickStorePerm', 'id', datum.target.id)"
+        }
+      ]
+    },
+    {
+      "name": "AdjustedtreeLayout",
+      "source": "treeLayoutAdjusted",
+      "transform": [
+        {
+          "type": "nest",
+          "keys": ["id", "parent"],
+          "generate": true
+        }
+      ]
+    },
+    {
+      "name": "linksAdjusted",
+      "source": "AdjustedtreeLayout",
+      "transform": [
+        {
+          "type": "treelinks"
+        },
+        {
+          "type": "linkpath",
+          "orient": "horizontal",
+          "shape": "diagonal",
+          "sourceY": {
+            "expr": "scale('yscale', datum.target.parent_y + nodeHeight/2 + ((indexof(lower(trim(reverse(split(datum.target.parent,'|'))[0])),'iwb energie france')>=0 || indexof(lower(trim(reverse(split(datum.target.parent,'|'))[0])),'iwb energie deutschland')>=0 || indexof(lower(trim(reverse(split(datum.target.parent,'|'))[0])),'iwb energie schweiz')>=0) ? countryLinkYOffset : 0))"
+          },
+          "sourceX": {
+            "expr": "scale('xscale', datum.target.parent_x + nodeWidth/2)"
+          },
+          "targetY": {
+            "expr": "scale('yscale', datum.target.y + nodeHeight/2)"
+          },
+          "targetX": {
+            "expr": "scale('xscale', datum.target.x + nodeWidth/2)"
+          }
+        },
+        {
+          "type": "filter",
+          "expr": " indata('treeClickStorePerm', 'id', datum.target.id)"
+        }
+      ]
+    }
+  ],
+  "scales": [
+    {
+      "name": "xscale",
+      "zero": false,
+      "domain": { "signal": "xdom" },
+      "range": { "signal": "xrange" }
+    },
+    {
+      "name": "yscale",
+      "zero": false,
+      "domain": { "signal": "ydom" },
+      "range": { "signal": "yrange" }
+    },
+    {
+      "name": "kpiscale",
+      "zero": false,
+      "domain": [0, 100],
+      "range": { "signal": "[0,scaledNodeWidth]" }
+    },
+    {
+      "name": "colour",
+      "type": "ordinal",
+      "range": ["#002A6F", "#002A6F", "#002A6F", "#002A6F", "#002A6F"],
+      "domain": {
+        "data": "visibleNodes",
+        "field": "treeParent"
+      }
+    }
+  ],
+  "marks": [
+    {
+      "type": "path",
+      "interactive": false,
+      "from": { "data": "links" },
+      "encode": {
+        "update": {
+          "path": { "field": "path" },
+          "strokeWidth": {
+            "signal": "indexof(nodeHighlight, datum.target.id)> -1? 2.5:0.4"
+          },
+          "stroke": {
+            "scale": "colour",
+            "signal": "reverse(pluck(treeAncestors('treeCalcs', datum.target.id), 'id'))[1]"
+          }
+        }
+      }
+    },
+    {
+      "type": "path",
+      "interactive": false,
+      "from": { "data": "linksAdjusted" },
+      "encode": {
+        "update": {
+          "path": { "field": "path" },
+          "strokeWidth": {
+            "signal": "indexof(nodeHighlight, datum.target.id)> -1? 2.5:0.4"
+          },
+          "stroke": {
+            "scale": "colour",
+            "signal": "reverse(pluck(treeAncestors('treeCalcs', datum.target.id), 'id'))[1]"
+          }
+        }
+      }
+    },
+    {
+      "type": "path",
+      "interactive": false,
+      "from": { "data": "linksSide" },
+      "encode": {
+        "update": {
+          "path": { "field": "path" },
+          "strokeWidth": {
+            "signal": "indexof(nodeHighlight, datum.target.id)> -1? 2.5:0.4"
+          },
+          "stroke": {
+            "scale": "colour",
+            "signal": "reverse(pluck(treeAncestors('treeCalcs', datum.target.id), 'id'))[1]"
+          }
+        }
+      }
+    },
+    {
+      "type": "rect",
+      "from": { "data": "countriesBox" },
+      "encode": {
+        "update": {
+          "x": { "field": "bxs" },
+          "y": { "field": "bys" },
+          "width": { "field": "bws" },
+          "height": { "field": "bhs" },
+          "fill": { "value": "white" },
+          "stroke": { "value": "#002A6F" },
+          "strokeWidth": { "value": 1.5 },
+          "cornerRadius": { "value": 6 }
+        }
+      }
+    },
+    {
+      "type": "text",
+      "from": { "data": "countriesBox" },
+      "encode": {
+        "update": {
+          "x": { "signal": "datum.bxs + datum.bws/2" },
+          "y": { "signal": "datum.bys + datum.bhs - 20" },
+          "align": { "value": "center" },
+          "baseline": { "value": "top" },
+          "text": { "value": "Länderholding" },
+          "font": { "value": "Calibri" },
+          "fontSize": { "signal": "scaledFont12" },
+          "fill": { "value": "#002A6F" }
+        }
+      }
+    },
+    {
+      "name": "node",
+      "description": "The parent node",
+      "type": "group",
+      "clip": false,
+      "from": { "data": "visibleNodes" },
+      "encode": {
+        "update": {
+          "xc": {
+            "signal": "scale('xscale', datum.x + nodeWidth/2)"
+          },
+          "width": {
+            "signal": "datum.depth==0 ? scaledNodeWidth*4.5 : (datum.title=='IWB Renewable Power AG' ? scaledNodeWidth*3.6 : ((indexof(lower(trim(reverse(split(datum.parent,'|'))[0])),'iwb energie france')>=0 || indexof(lower(trim(reverse(split(datum.parent,'|'))[0])),'iwb energie deutschland')>=0 || indexof(lower(trim(reverse(split(datum.parent,'|'))[0])),'iwb energie schweiz')>=0) ? scaledNodeWidth*countryChildrenExtraGap : scaledNodeWidth))"
+          },
+          "yc": { "field": "y", "scale": "yscale" },
+          "height": {
+            "signal": "datum.depth==0 ? scaledNodeHeight*1.25 : (datum.title=='IWB Renewable Power AG' ? scaledNodeHeight*1.15 : ((indexof(lower(trim(reverse(split(datum.parent,'|'))[0])),'iwb energie france')>=0 || indexof(lower(trim(reverse(split(datum.parent,'|'))[0])),'iwb energie deutschland')>=0 || indexof(lower(trim(reverse(split(datum.parent,'|'))[0])),'iwb energie schweiz')>=0) ? scaledNodeHeight*countryChildHeightFactor : scaledNodeHeight))"
+          },
+          "fill": { "value": "white" },
+          "stroke": {
+            "signal": "merge(hsl(scale('colour', datum.treeParent)), {l:0.79})"
+          },
+          "cornerRadius": { "value": 2 },
+          "cursor": { "signal": "datum.children>0?'pointer':''" },
+          "tooltip": { "signal": "" }
+        }
+      },
+      "marks": [
+        {
+          "name": "highlight",
+          "description": "highlight (seems like a Vega bug as this doens't work on the group element)",
+          "type": "rect",
+          "interactive": false,
+          "encode": {
+            "update": {
+              "x": { "signal": "item.mark.group.x1" },
+              "y": { "signal": "0" },
+              "fill": {
+                "signal": "indexof(nodeHighlight, parent.id)> -1? merge(hsl(scale('colour', parent.treeParent)), {l:0.82}):0"
+              },
+              "stroke": {
+                "signal": "indexof(nodeHighlight, parent.id)> -1? merge(hsl(scale('colour', parent.treeParent)), {l:0.79}):0"
+              },
+              "height": { "signal": "item.mark.group.height" },
+              "width": { "signal": "item.mark.group.width" }
+            }
+          }
+        },
+        {
+          "name": "KPI background",
+          "description": "KPI background",
+          "type": "rect",
+          "interactive": false,
+          "clip": true,
+          "encode": {
+            "update": {
+              "x": { "signal": "item.mark.group.x1" },
+              "y": { "signal": "item.mark.group.height-scaledKPIHeight" },
+              "height": { "signal": "scaledKPIHeight" },
+              "width": { "signal": "(item.mark.group.width)" },
+              "fill": {
+                "scale": "colour",
+                "signal": "parent.treeParent"
+              },
+              "opacity": { "value": 0.2 }
+            }
+          }
+        },
+        {
+          "name": "KPI",
+          "description": "KPI",
+          "type": "rect",
+          "interactive": false,
+          "clip": true,
+          "encode": {
+            "update": {
+              "x": { "signal": "item.mark.group.x1" },
+              "y": { "signal": "item.mark.group.height-scaledKPIHeight" },
+              "height": { "signal": "scaledKPIHeight" },
+              "width": { "signal": "scale('kpiscale',parent.kpi)" },
+              "fill": {
+                "scale": "colour",
+                "signal": "parent.treeParent"
+              }
+            }
+          }
+        },
+        {
+          "type": "text",
+          "interactive": false,
+          "name": "name",
+          "encode": {
+            "update": {
+              "x": { "signal": "item.mark.group.width/2" },
+              "y": { "signal": "(22 / span(xdom)) * width" },
+              "align": { "value": "center" },
+              "fontWeight": { "value": "800" },
+              "baseline": { "value": "top" },
+              "fill": {
+                "scale": "colour",
+                "signal": "parent.treeParent"
+              },
+              "text": { "signal": "parent.title" },
+              "fontSize": { "signal": "scaledFont13" },
+              "limit": { "signal": "scaledNodeWidth-scaledLimit" },
+              "font": { "value": "Calibri" }
+            }
+          }
+        },
+        {
+          "type": "text",
+          "interactive": false,
+          "name": "person",
+          "encode": {
+            "update": {
+              "x": { "signal": "item.mark.group.width/2" },
+              "y": { "signal": "item.mark.group.height/2 + 5" },
+              "align": { "value": "center" },
+              "baseline": { "value": "middle" },
+              "fill": { "signal": "'#4D4B44'" },
+              "text": { "signal": "parent.person" },
+              "fontSize": { "signal": "scaledFont11" },
+              "limit": { "signal": "item.mark.group.width - scaledLimit" },
+              "font": { "value": "Calibri" }
+            }
+          }
+        },
+        {
+          "type": "text",
+          "interactive": false,
+          "name": "node children",
+          "encode": {
+            "update": {
+              "x": { "signal": "item.mark.group.width - (9/ span(xdom))*width" },
+              "y": { "signal": "item.mark.group.height/2" },
+              "align": { "value": "right" },
+              "baseline": { "value": "middle" },
+              "fill": {
+                "scale": "colour",
+                "signal": "parent.treeParent"
+              },
+              "text": { "signal": "parent.children>0?parent.children:''" },
+              "fontSize": { "signal": "scaledFont12" },
+              "font": { "value": "Calibri" }
+            }
+          }
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Adjusted initial display depth and corrected node text to show company names as primary labels and person names as secondary.

The `startingDepth` signal was changed from `1` to `2` to ensure the correct hierarchical level is displayed initially. Additionally, the main text of each node now correctly displays the company `title`, with the `person` name added as a secondary text element, resolving an issue where person names were used as primary labels.

---
<a href="https://cursor.com/background-agent?bcId=bc-44c4d60b-89d4-4ce0-a2da-9486751a8ab1">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-44c4d60b-89d4-4ce0-a2da-9486751a8ab1">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

