### PR TITLE
Organize and visualize hierarchical data

### DIFF
--- a/fixed_vega_spec.json
+++ b/fixed_vega_spec.json
@@ -1,0 +1,726 @@
+{
+    "$schema": "https://vega.github.io/schema/vega/v5.json",
+    "autosize": {
+        "type": "fit",
+        "contains": "padding",
+        "resize": true
+    },
+    "description": "Organigram IWB - Cleaned",
+    "background": null,
+    "padding": 50,
+    "signals": [
+        {
+            "name": "nodeWidth",
+            "value": 300
+        },
+        {
+            "name": "nodeHeight",
+            "value": 70
+        },
+        {
+            "name": "verticalNodeGap",
+            "value": 350
+        },
+        {
+            "name": "horizontalNodeGap",
+            "value": -150
+        },
+        {
+            "name": "rpExtraGap",
+            "value": 10
+        },
+        {
+            "name": "countryChildrenExtraGap",
+            "value": 1.25
+        },
+        {
+            "name": "countryChildHeightFactor",
+            "value": 1.0
+        },
+        {
+            "name": "countryLinkYOffset",
+            "value": 25
+        },
+        {
+            "name": "franceXOffset",
+            "value": -150
+        },
+        {
+            "name": "deutschlandXOffset",
+            "value": -150
+        },
+        {
+            "name": "schweizXOffset",
+            "value": -150
+        },
+        {
+            "name": "countryBoxPadLeft",
+            "value": 40
+        },
+        {
+            "name": "countryBoxPadRight",
+            "value": 340
+        },
+        {
+            "name": "countryBoxPadTop",
+            "value": 40
+        },
+        {
+            "name": "countryBoxPadBottom",
+            "value": 100
+        },
+        {
+            "name": "countryBoxStroke",
+            "value": 2
+        },
+        {
+            "name": "countryBoxCorner",
+            "value": 10
+        },
+        {
+            "name": "countryBoxLabelSize",
+            "value": 22
+        },
+        {
+            "name": "sideParentXOffset",
+            "value": -145
+        },
+        {
+            "name": "sideParentYOffset",
+            "value": 0
+        },
+        {
+            "name": "kwoXShift",
+            "value": 63
+        },
+        {
+            "name": "kwoYShift",
+            "value": 200
+        },
+        {
+            "name": "v2BlockXShift",
+            "value": 200
+        },
+        {
+            "name": "v2BlockYShift",
+            "value": 100
+        },
+        {
+            "name": "wrapChars",
+            "value": 40
+        },
+        {
+            "name": "sideBusPad",
+            "value": 60
+        },
+        {
+            "name": "busYOffset",
+            "value": 40
+        },
+        {
+            "name": "busLänderholdingAnsatzNod",
+            "value": 375
+        },
+        {
+            "name": "iwbDirectBusXPosition",
+            "value": 640
+        },
+        {
+            "name": "iwbDirectBusYStart",
+            "value": 20
+        },
+        {
+            "name": "iwbDirectBusYEnd",
+            "value": -64
+        },
+        {
+            "name": "iwbDirectBusParentY",
+            "value": 20
+        },
+        {
+            "name": "iwbDirectChildrenYOffset",
+            "value": -30
+        },
+        {
+            "name": "iwbDirectChildrenLineLength",
+            "value": 50
+        },
+        {
+            "name": "startingDepth",
+            "value": 99,
+            "on": [
+                {
+                    "events": {
+                        "type": "timer",
+                        "throttle": 0
+                    },
+                    "update": "-1"
+                }
+            ]
+        },
+        {
+            "name": "node",
+            "value": 0,
+            "on": [
+                {
+                    "events": {
+                        "type": "click",
+                        "markname": "node"
+                    },
+                    "update": "datum.id"
+                },
+                {
+                    "events": {
+                        "type": "timer",
+                        "throttle": 10
+                    },
+                    "update": "0"
+                }
+            ]
+        },
+        {
+            "name": "nodeHighlight",
+            "value": "[0]",
+            "on": [
+                {
+                    "events": {
+                        "type": "mouseover",
+                        "markname": "node"
+                    },
+                    "update": "pluck(treeAncestors('treeCalcs', datum.id), 'id')"
+                },
+                {
+                    "events": {
+                        "type": "mouseout"
+                    },
+                    "update": "[0]"
+                }
+            ]
+        },
+        {
+            "name": "isExpanded",
+            "value": 0,
+            "on": [
+                {
+                    "events": {
+                        "type": "click",
+                        "markname": "node"
+                    },
+                    "update": "datum.children > 0 && indata('treeClickStorePerm', 'id', datum.childrenIds[0])?true:false"
+                }
+            ]
+        },
+        {
+            "name": "xrange",
+            "update": "[0, width]"
+        },
+        {
+            "name": "yrange",
+            "update": "[0, height]"
+        },
+        {
+            "name": "down",
+            "value": null,
+            "on": [
+                {
+                    "events": "touchend",
+                    "update": "null"
+                },
+                {
+                    "events": "mousedown, touchstart",
+                    "update": "xy()"
+                }
+            ]
+        },
+        {
+            "name": "xcur",
+            "value": null,
+            "on": [
+                {
+                    "events": "mousedown, touchstart, touchend",
+                    "update": "slice(xdom)"
+                }
+            ]
+        },
+        {
+            "name": "ycur",
+            "value": null,
+            "on": [
+                {
+                    "events": "mousedown, touchstart, touchend",
+                    "update": "slice(ydom)"
+                }
+            ]
+        },
+        {
+            "name": "delta",
+            "value": [0, 0],
+            "on": [
+                {
+                    "events": [
+                        {
+                            "source": "window",
+                            "type": "mousemove",
+                            "consume": true,
+                            "between": [
+                                {"type": "mousedown"},
+                                {"source": "window", "type": "mouseup"}
+                            ]
+                        },
+                        {
+                            "type": "touchmove",
+                            "consume": true,
+                            "filter": "event.touches.length === 1"
+                        }
+                    ],
+                    "update": "down ? [down[0]-x(), down[1]-y()] : [0,0]"
+                }
+            ]
+        },
+        {
+            "name": "anchor",
+            "value": [0, 0],
+            "on": [
+                {
+                    "events": "wheel",
+                    "update": "[invert('xscale', x()), invert('yscale', y())]"
+                },
+                {
+                    "events": {
+                        "type": "touchstart",
+                        "filter": "event.touches.length===2"
+                    },
+                    "update": "[(xdom[0] + xdom[1]) / 2, (ydom[0] + ydom[1]) / 2]"
+                }
+            ]
+        },
+        {
+            "name": "xext",
+            "update": "[0,width]"
+        },
+        {
+            "name": "yext",
+            "update": "[0,height]"
+        },
+        {
+            "name": "zoom",
+            "value": 1,
+            "on": [
+                {
+                    "events": "wheel!",
+                    "force": true,
+                    "update": "pow(1.001, event.deltaY * pow(16, event.deltaMode))"
+                }
+            ]
+        },
+        {
+            "name": "xdom",
+            "update": "slice(xext)",
+            "on": [
+                {
+                    "events": {"signal": "delta"},
+                    "update": "[xcur[0] + span(xcur) * delta[0] / width, xcur[1] + span(xcur) * delta[0] / width]"
+                },
+                {
+                    "events": {"signal": "zoom"},
+                    "update": "[anchor[0] + (xdom[0] - anchor[0]) * zoom, anchor[0] + (xdom[1] - anchor[0]) * zoom]"
+                },
+                {
+                    "events": "dblclick",
+                    "update": "[0,width]"
+                }
+            ]
+        },
+        {
+            "name": "ydom",
+            "update": "slice(yext)",
+            "on": [
+                {
+                    "events": {"signal": "delta"},
+                    "update": "[ycur[0] + span(ycur) * delta[1] / height, ycur[1] + span(ycur) * delta[1] / height]"
+                },
+                {
+                    "events": {"signal": "zoom"},
+                    "update": "[anchor[1] + (ydom[0] - anchor[1]) * zoom, anchor[1] + (ydom[1] - anchor[1]) * zoom]"
+                },
+                {
+                    "events": "dblclick",
+                    "update": "[0,height]"
+                }
+            ]
+        },
+        {
+            "name": "scaledNodeWidth",
+            "update": "(nodeWidth/ span(xdom))*width"
+        },
+        {
+            "name": "scaledNodeHeight",
+            "update": "abs(nodeHeight/ span(ydom))*height"
+        },
+        {
+            "name": "scaledFont13",
+            "update": "(22/ span(xdom))*width"
+        },
+        {
+            "name": "scaledFont12",
+            "update": "(15/ span(xdom))*width"
+        },
+        {
+            "name": "scaledFont11",
+            "update": "(14/ span(xdom))*width"
+        },
+        {
+            "name": "scaledKPIHeight",
+            "update": "(5/ span(xdom))*width"
+        },
+        {
+            "name": "scaledLimit",
+            "update": "(20/ span(xdom))*width"
+        }
+    ],
+    "data": [
+        {
+            "name": "dataset"
+        },
+        {
+            "name": "processedData",
+            "source": "dataset",
+            "transform": [
+                { "type": "formula", "as": "h_level1", "expr": "trim(datum.horizontal_level_1 || '')" },
+                { "type": "formula", "as": "v_level1", "expr": "trim(datum.vertikal_level_1 || '')" },
+                { "type": "formula", "as": "h_level2", "expr": "trim(datum.horizontal_level_2 || '')" },
+                { "type": "formula", "as": "v_level2", "expr": "trim(datum.vertikal_level_2 || '')" },
+                { "type": "formula", "as": "h_level3", "expr": "trim(datum.horizontal_level_3 || '')" },
+                { "type": "formula", "as": "v_level3", "expr": "trim(datum.vertikal_level_3 || '')" },
+                { "type": "formula", "as": "h_level4", "expr": "trim(datum.horizontal_level_4 || '')" },
+                { "type": "formula", "as": "v_level4", "expr": "trim(datum.vertikal_level_4 || '')" },
+                { "type": "formula", "as": "h_level5", "expr": "trim(datum.horizontal_level_5 || '')" },
+                { "type": "formula", "as": "v_level5", "expr": "trim(datum.vertikal_level_5 || '')" },
+                { "type": "filter", "expr": "datum.h_level1 != '' && datum.h_level1 != null" }
+            ]
+        },
+        {
+            "name": "hierarchy",
+            "source": "processedData",
+            "transform": [
+                { "type": "formula", "expr": "{key: datum.h_level1, parent: null, person: '', kpi: 0, LevelId: 1, isVertical: false}", "as": "l1h" },
+                
+                { "type": "formula", "expr": "datum.h_level2 != '' && datum.h_level2 != null ? {key: datum.h_level1 + '|' + datum.h_level2, parent: datum.h_level1, person: '', kpi: 0, LevelId: 2, isVertical: false} : null", "as": "l2h" },
+                { "type": "formula", "expr": "datum.v_level2 != '' && datum.v_level2 != null && datum.v_level2 != datum.h_level2 ? {key: datum.h_level1 + '|' + datum.v_level2, parent: datum.h_level1, person: '', kpi: 0, LevelId: 2, isVertical: true} : null", "as": "l2v" },
+                
+                { "type": "formula", "expr": "datum.h_level3 != '' && datum.h_level3 != null && datum.h_level2 != '' ? {key: datum.h_level1 + '|' + datum.h_level2 + '|' + datum.h_level3, parent: datum.h_level1 + '|' + datum.h_level2, person: '', kpi: 0, LevelId: 3, isVertical: false} : null", "as": "l3h" },
+                { "type": "formula", "expr": "datum.v_level3 != '' && datum.v_level3 != null && datum.v_level3 != datum.h_level3 ? {key: datum.h_level1 + '|' + datum.h_level2 + '|' + datum.h_level3 + '|' + datum.v_level3, parent: datum.h_level1 + '|' + datum.h_level2 + '|' + datum.h_level3, person: '', kpi: 0, LevelId: 3, isVertical: true} : null", "as": "l3v" },
+                
+                { "type": "formula", "expr": "datum.v_level4 != '' && datum.v_level4 != null && datum.h_level3 != '' ? {key: datum.h_level1 + '|' + datum.h_level2 + '|' + datum.h_level3 + '|' + datum.v_level4, parent: datum.h_level1 + '|' + datum.h_level2 + '|' + datum.h_level3, person: '', kpi: 0, LevelId: 4, isVertical: true} : null", "as": "l4v" },
+                
+                { "type": "formula", "expr": "datum.h_level5 != '' && datum.h_level5 != null && datum.v_level3 != '' ? {key: datum.h_level1 + '|' + datum.h_level2 + '|' + datum.h_level3 + '|' + datum.v_level3 + '|' + datum.h_level5, parent: datum.h_level1 + '|' + datum.h_level2 + '|' + datum.h_level3 + '|' + datum.v_level3, person: '', kpi: 0, LevelId: 5, isVertical: false} : null", "as": "l5h" }
+                ,
+                
+                { "type": "fold", "fields": ["l1h", "l2h", "l2v", "l3h", "l3v", "l4v", "l5h"] },
+                { "type": "filter", "expr": "datum.value != null" },
+                { "type": "formula", "expr": "datum.value.key", "as": "id" },
+                { "type": "formula", "expr": "reverse(split(datum.value.key,'|'))[0]", "as": "title" },
+                { "type": "formula", "expr": "datum.value.parent", "as": "parent" },
+                { "type": "formula", "expr": "datum.value.LevelId", "as": "LevelId" },
+                { "type": "formula", "expr": "datum.value.isVertical", "as": "isVertical" },
+                { "type": "filter", "expr": "isValid(datum.title) && datum.title != '' && datum.title != 'null' && datum.title != 'undefined'" },
+                { "type": "aggregate", "groupby": ["id", "parent", "title", "LevelId", "isVertical"], "fields": ["id"], "ops": ["count"], "as": ["count"] },
+                { "type": "formula", "expr": "''", "as": "person" },
+                { "type": "formula", "expr": "0", "as": "kpi" }
+            ]
+        },
+        {
+            "name": "filteredHierarchy",
+            "source": "hierarchy",
+            "transform": [
+                { "type": "filter", "expr": "datum.LevelId <= 5" }
+            ]
+        },
+        {
+            "name": "treeCalcs",
+            "source": "filteredHierarchy",
+            "transform": [
+                { "type": "stratify", "key": "id", "parentKey": "parent" },
+                { "type": "tree", "method": "tidy", "separation": false, "as": ["y", "x", "depth", "children"] }
+            ]
+        },
+        {
+            "name": "nodeClassification",
+            "source": "treeCalcs",
+            "transform": [
+                { "type": "formula", "expr": "lower(trim(reverse(split(datum.id,'|'))[0]))", "as": "title_lower" },
+                { "type": "formula", "expr": "lower(trim((reverse(split(datum.parent,'|'))[0] || '')))", "as": "parent_title_lower" },
+                { "type": "formula", "expr": "datum.LevelId==2 && datum.isVertical==false && indexof(datum.parent_title_lower,'iwb renewable power ag')>=0 && !(indexof(datum.title_lower,'iwb energie france')>=0 || indexof(datum.title_lower,'iwb energie deutschland')>=0 || indexof(datum.title_lower,'iwb energie schweiz')>=0)", "as": "isSide" },
+                { "type": "formula", "expr": "datum.isVertical == true", "as": "stackMe" },
+                { "type": "formula", "expr": "indexof((datum.parent_title_lower||''),'iwb energie ')==0 ? datum.parent_title_lower : null", "as": "country_key" }
+            ]
+        },
+        {
+            "name": "treeClickStoreTemp",
+            "source": "nodeClassification",
+            "transform": [
+                { "type": "filter", "expr": "startingDepth!=-1 ? datum.depth <= (startingDepth + 3) : true" }
+            ]
+        },
+        {
+            "name": "treeClickStorePerm",
+            "values": [],
+            "on": [
+                { "trigger": "startingDepth>=0", "insert": "data('treeClickStoreTemp')" },
+                { "trigger": "node", "insert": "!isExpanded? data('treeClickStoreTemp'):false" },
+                { "trigger": "node", "remove": "isExpanded?data('treeClickStoreTemp'):false" }
+            ]
+        },
+        {
+            "name": "mainTreeLayout",
+            "source": "nodeClassification",
+            "transform": [
+                { "type": "filter", "expr": "indata('treeClickStorePerm','id', datum.id)" },
+                { "type": "filter", "expr": "!datum.stackMe && !datum.isSide" },
+                { "type": "filter", "expr": "!(indexof(datum.parent_title_lower,'iwb energie france')>=0 || indexof(datum.parent_title_lower,'iwb energie deutschland')>=0 || indexof(datum.parent_title_lower,'iwb energie schweiz')>=0) || indexof(datum.title_lower,'juvent sa')>=0 || indexof(datum.title_lower,'swisspower green gas')>=0" },
+                { "type": "formula", "expr": "indexof(datum.title_lower,'iwb energie france')>=0 ? 0 : indexof(datum.title_lower,'iwb energie deutschland')>=0 ? 1 : indexof(datum.title_lower,'iwb energie schweiz')>=0 ? 2 : 99", "as": "orderHint" },
+                { "type": "collect", "sort": {"field": ["parent", "orderHint", "id"], "order": ["ascending", "ascending", "ascending"]} },
+                { "type": "stratify", "key": "id", "parentKey": "parent" },
+                { "type": "tree", "method": "tidy", "nodeSize": [{"signal": "nodeHeight+verticalNodeGap"}, {"signal": "nodeWidth+horizontalNodeGap"}], "separation": false, "as": ["x", "y", "depth", "children"] },
+                { "type": "formula", "expr": "datum.title == 'IWB Renewable Power AG' ? datum.x - 210 : datum.x", "as": "x" },
+                { "type": "formula", "expr": "datum.x + (indexof(datum.parent_title_lower,'iwb renewable power ag')>=0 ? (indexof(datum.title_lower,'iwb energie france')>=0 ? franceXOffset : indexof(datum.title_lower,'iwb energie deutschland')>=0 ? deutschlandXOffset : indexof(datum.title_lower,'iwb energie schweiz')>=0 ? schweizXOffset : 0) : 0)", "as": "x" },
+                { "type": "formula", "expr": "datum.y + (indexof(datum.parent_title_lower,'iwb renewable power ag')>=0 ? rpExtraGap : 0)", "as": "y" }
+            ]
+        },
+        {
+            "name": "stackedNodes",
+            "source": "nodeClassification",
+            "transform": [
+                { "type": "filter", "expr": "datum.stackMe || datum.LevelId == 4" },
+                { "type": "lookup", "from": "mainTreeLayout", "key": "id", "fields": ["parent"], "values": ["x", "y"], "as": ["parent_x", "parent_y"], "default": null },
+                { "type": "filter", "expr": "isValid(datum.parent_x) && isValid(datum.parent_y)" },
+                { "type": "window", "sort": {"field": "id", "order": "ascending"}, "ops": ["dense_rank"], "fields": ["id"], "groupby": ["parent"], "as": ["d_rank"] },
+                { "type": "formula", "as": "x", "expr": "datum.parent_x + nodeWidth + 50" },
+                { "type": "formula", "as": "y", "expr": "datum.parent_y + nodeHeight + (datum.d_rank) * (nodeHeight + 20)" }
+            ]
+        },
+        {
+            "name": "sideNodes",
+            "source": "nodeClassification",
+            "transform": [
+                { "type": "filter", "expr": "datum.isSide" },
+                { "type": "lookup", "from": "mainTreeLayout", "key": "id", "fields": ["parent"], "values": ["x", "y"], "as": ["parent_x", "parent_y"], "default": null },
+                { "type": "window", "sort": {"field": "id", "order": "ascending"}, "ops": ["dense_rank"], "fields": ["id"], "groupby": ["parent"], "as": ["d_rank"] },
+                { "type": "formula", "expr": "datum.parent_x + nodeWidth + 450 + sideParentXOffset + (indexof(datum.title_lower,'kraftwerke oberhasli ag')>=0 ? kwoXShift : 0)", "as": "x" },
+                { "type": "formula", "expr": "datum.parent_y + 100 + (datum.d_rank - 1) * (nodeHeight + 8) + sideParentYOffset + (indexof(datum.title_lower,'kraftwerke oberhasli ag')>=0 ? kwoYShift : 0)", "as": "y" }
+            ]
+        },
+        {
+            "name": "iwbDirectNodes",
+            "source": "nodeClassification",
+            "transform": [
+                { "type": "filter", "expr": "indexof(datum.title_lower,'juvent sa')>=0 || indexof(datum.title_lower,'swisspower green gas')>=0" },
+                { "type": "lookup", "from": "mainTreeLayout", "key": "id", "fields": ["parent"], "values": ["x", "y"], "as": ["parent_x", "parent_y"], "default": null },
+                { "type": "window", "sort": {"field": "id", "order": "ascending"}, "ops": ["dense_rank"], "fields": ["id"], "groupby": ["parent"], "as": ["d_rank"] },
+                { "type": "formula", "expr": "datum.parent_x + nodeWidth + 600", "as": "x" },
+                { "type": "formula", "expr": "datum.parent_y + nodeHeight + 200 + (datum.d_rank) * (nodeHeight + 8)", "as": "y" }
+            ]
+        },
+        {
+            "name": "newVerticalLevel2",
+            "source": "nodeClassification",
+            "transform": [
+                { "type": "filter", "expr": "datum.LevelId == 2 && datum.isVertical == true" },
+                { "type": "lookup", "from": "mainTreeLayout", "key": "id", "fields": ["parent"], "values": ["x", "y"], "as": ["parent_x", "parent_y"], "default": null },
+                { "type": "window", "sort": {"field": "id", "order": "ascending"}, "ops": ["dense_rank"], "fields": ["id"], "groupby": ["parent"], "as": ["d_rank"] },
+                { "type": "formula", "expr": "datum.parent_x + 700", "as": "x" },
+                { "type": "formula", "expr": "datum.parent_y + 100 + (datum.d_rank) * (nodeHeight + 20)", "as": "y" }
+            ]
+        },
+        {
+            "name": "newVerticalLevel3",
+            "source": "nodeClassification",
+            "transform": [
+                { "type": "filter", "expr": "datum.LevelId == 3 && datum.isVertical == true" },
+                { "type": "lookup", "from": "newVerticalLevel2", "key": "id", "fields": ["parent"], "values": ["x", "y"], "as": ["parent_x", "parent_y"], "default": null },
+                { "type": "filter", "expr": "isValid(datum.parent_x) && isValid(datum.parent_y)" },
+                { "type": "window", "sort": {"field": "id", "order": "ascending"}, "ops": ["dense_rank"], "fields": ["id"], "groupby": ["parent"], "as": ["d_rank"] },
+                { "type": "formula", "expr": "datum.parent_x + 50", "as": "x" },
+                { "type": "formula", "expr": "datum.parent_y + 100 + (datum.d_rank) * (nodeHeight + 10)", "as": "y" }
+            ]
+        },
+        {
+            "name": "newHorizontalLevel5",
+            "source": "nodeClassification",
+            "transform": [
+                { "type": "filter", "expr": "datum.LevelId == 5 && datum.isVertical == false" },
+                { "type": "lookup", "from": "stackedNodes", "key": "id", "fields": ["parent"], "values": ["x", "y"], "as": ["parent_x_stacked", "parent_y_stacked"], "default": null },
+                { "type": "lookup", "from": "mainTreeLayout", "key": "id", "fields": ["parent"], "values": ["x", "y"], "as": ["parent_x_main", "parent_y_main"], "default": null },
+                { "type": "formula", "expr": "isValid(datum.parent_x_stacked) ? datum.parent_x_stacked : datum.parent_x_main", "as": "parent_x" },
+                { "type": "formula", "expr": "isValid(datum.parent_y_stacked) ? datum.parent_y_stacked : datum.parent_y_main", "as": "parent_y" },
+                
+                { "type": "filter", "expr": "isValid(datum.parent_x) && isValid(datum.parent_y)" },
+                { "type": "window", "sort": {"field": "id", "order": "ascending"}, "ops": ["dense_rank"], "fields": ["id"], "groupby": ["parent"], "as": ["d_rank"] },
+                
+                { "type": "formula", "expr": "datum.parent_x + nodeWidth + 50", "as": "x" },
+                { "type": "formula", "expr": "datum.parent_y + (datum.d_rank - 1) * (nodeHeight + 10)", "as": "y" }
+            ]
+        },
+        {
+            "name": "allNodes",
+            "source": ["mainTreeLayout", "stackedNodes", "sideNodes", "iwbDirectNodes", "newVerticalLevel2", "newVerticalLevel3", "newHorizontalLevel5"],
+            "transform": [
+                { "type": "formula", "as": "wrapBreak", "expr": "length(datum.title) <= wrapChars ? -1 : (indexof(slice(datum.title, wrapChars, length(datum.title)),' ')>=0 ? wrapChars + indexof(slice(datum.title, wrapChars, length(datum.title)),' ') : wrapChars)" },
+                { "type": "formula", "as": "title_wrapped", "expr": "datum.wrapBreak < 0 ? datum.title : slice(datum.title, 0, datum.wrapBreak) + '\\n' + slice(datum.title, datum.wrapBreak + (slice(datum.title, datum.wrapBreak, datum.wrapBreak+1)==' ' ? 1 : 0), length(datum.title))" }
+            ]
+        },
+        {
+            "name": "visibleNodes",
+            "source": "allNodes",
+            "transform": [
+                { "type": "filter", "expr": "indata('treeClickStorePerm','id', datum.id)" }
+            ]
+        },
+        {
+            "name": "countriesBox",
+            "source": "mainTreeLayout",
+            "transform": [
+                { "type": "filter", "expr": "indexof(datum.parent_title_lower,'iwb renewable power ag')>=0" },
+                { "type": "filter", "expr": "indexof(datum.title_lower,'iwb energie france')>=0 || indexof(datum.title_lower,'iwb energie deutschland')>=0 || indexof(datum.title_lower,'iwb energie schweiz')>=0" },
+                { "type": "aggregate", "fields": ["x", "x", "y", "y"], "ops": ["min", "max", "min", "max"], "as": ["minx", "maxx", "miny", "maxy"] },
+                { "type": "formula", "expr": "datum.minx - countryBoxPadLeft", "as": "bx" },
+                { "type": "formula", "expr": "datum.miny - countryBoxPadTop", "as": "by" },
+                { "type": "formula", "expr": "(datum.maxx - datum.minx) + countryBoxPadLeft + countryBoxPadRight", "as": "bw" },
+                { "type": "formula", "expr": "(datum.maxy - datum.miny) + countryBoxPadTop + countryBoxPadBottom", "as": "bh" },
+                { "type": "formula", "expr": "scale('xscale', datum.bx)", "as": "bxs" },
+                { "type": "formula", "expr": "scale('yscale', datum.by)", "as": "bys" },
+                { "type": "formula", "expr": "scale('xscale', datum.bx + datum.bw) - scale('xscale', datum.bx)", "as": "bws" },
+                { "type": "formula", "expr": "scale('yscale', datum.by + datum.bh) - scale('yscale', datum.by)", "as": "bhs" }
+            ]
+        },
+        {
+            "name": "links",
+            "source": "allNodes",
+            "transform": [
+                { "type": "filter", "expr": "datum.parent != null" },
+                { "type": "lookup", "from": "allNodes", "key": "id", "fields": ["parent"], "values": ["x", "y"], "as": ["parent_x", "parent_y"], "default": {"x": 0, "y": 0} },
+                { "type": "filter", "expr": "isValid(datum.parent_x) && isValid(datum.parent_y)" },
+                { "type": "linkpath", "orient": "horizontal", "shape": "orthogonal", 
+                  "sourceY": {"expr": "scale('yscale', datum.parent_y + nodeHeight/2)"}, 
+                  "sourceX": {"expr": "scale('xscale', datum.parent_x + nodeWidth)"}, 
+                  "targetY": {"expr": "scale('yscale', datum.y + nodeHeight/2)"}, 
+                  "targetX": {"expr": "scale('xscale', datum.x)"} },
+                { "type": "filter", "expr": "indata('treeClickStorePerm', 'id', datum.id)" }
+            ]
+        }
+    ],
+    "scales": [
+        {
+            "name": "xscale",
+            "zero": false,
+            "domain": {"signal": "xdom"},
+            "range": {"signal": "xrange"}
+        },
+        {
+            "name": "yscale",
+            "zero": false,
+            "domain": {"signal": "ydom"},
+            "range": {"signal": "yrange"}
+        },
+        {
+            "name": "kpiscale",
+            "zero": false,
+            "domain": [0, 100],
+            "range": {"signal": "[0,scaledNodeWidth]"}
+        },
+        {
+            "name": "colour",
+            "type": "ordinal",
+            "range": ["#002A6F", "#0066CC", "#4D94FF", "#80B3FF", "#B3D1FF"],
+            "domain": {"data": "visibleNodes", "field": "LevelId"}
+        }
+    ],
+    "marks": [
+        {
+            "type": "rect",
+            "from": {"data": "countriesBox"},
+            "encode": {
+                "update": {
+                    "x": {"field": "bxs"},
+                    "y": {"field": "bys"},
+                    "width": {"field": "bws"},
+                    "height": {"field": "bhs"},
+                    "fill": {"value": "white"},
+                    "stroke": {"value": "#002A6F"},
+                    "strokeWidth": {"signal": "countryBoxStroke"},
+                    "cornerRadius": {"signal": "countryBoxCorner"}
+                }
+            }
+        },
+        {
+            "type": "text",
+            "from": {"data": "countriesBox"},
+            "encode": {
+                "update": {
+                    "x": {"signal": "datum.bxs + datum.bws/2"},
+                    "y": {"signal": "datum.bys + datum.bhs - 20"},
+                    "align": {"value": "center"},
+                    "baseline": {"value": "top"},
+                    "text": {"value": "Länderholding"},
+                    "font": {"value": "Calibri"},
+                    "fontSize": {"signal": "countryBoxLabelSize"},
+                    "fontWeight": {"value": "bold"},
+                    "fill": {"value": "#002A6F"}
+                }
+            }
+        },
+        {
+            "type": "path",
+            "interactive": false,
+            "from": {"data": "links"},
+            "encode": {
+                "update": {
+                    "path": {"field": "path"},
+                    "strokeWidth": {"signal": "indexof(nodeHighlight, datum.id)> -1? 2.5:0.4"},
+                    "stroke": {"scale": "colour", "field": "LevelId"}
+                }
+            }
+        },
+        {
+            "name": "node",
+            "type": "group",
+            "clip": false,
+            "from": {"data": "visibleNodes"},
+            "encode": {
+                "update": {
+                    "xc": {"signal": "scale('xscale', datum.x + nodeWidth/2)"},
+                    "width": {"signal": "datum.depth==0 ? scaledNodeWidth*5 : (datum.title=='IWB Renewable Power AG' ? scaledNodeWidth*3.6 : ((indexof(datum.parent_title_lower,'iwb energie france')>=0 || indexof(datum.parent_title_lower,'iwb energie deutschland')>=0 || indexof(datum.parent_title_lower,'iwb energie schweiz')>=0) ? scaledNodeWidth*countryChildrenExtraGap : scaledNodeWidth))"},
+                    "yc": {"field": "y", "scale": "yscale"},
+                    "height": {"signal": "datum.depth==0 ? scaledNodeHeight*1.25 : (datum.title=='IWB Renewable Power AG' ? scaledNodeHeight*1.15 : ((indexof(datum.parent_title_lower,'iwb energie france')>=0 || indexof(datum.parent_title_lower,'iwb energie deutschland')>=0 || indexof(datum.parent_title_lower,'iwb energie schweiz')>=0) ? scaledNodeHeight*countryChildHeightFactor : scaledNodeHeight))"},
+                    "fill": {"value": "white"},
+                    "stroke": {"scale": "colour", "field": "LevelId"},
+                    "cornerRadius": {"value": 2},
+                    "cursor": {"signal": "datum.children>0?'pointer':''"}
+                }
+            },
+            "marks": [
+                {
+                    "type": "text",
+                    "interactive": false,
+                    "encode": {
+                        "update": {
+                            "x": {"signal": "item.mark.group.width/2"},
+                            "y": {"signal": "(22 / span(xdom)) * width"},
+                            "align": {"value": "center"},
+                            "fontWeight": {"value": "800"},
+                            "baseline": {"value": "top"},
+                            "fill": {"scale": "colour", "signal": "parent.LevelId"},
+                            "text": {"signal": "parent.title_wrapped"},
+                            "lineBreak": {"value": "\\n"},
+                            "lineHeight": {"signal": "scaledFont13 * 1.15"},
+                            "fontSize": {"signal": "scaledFont13"},
+                            "limit": {"signal": "scaledNodeWidth-scaledLimit"},
+                            "font": {"value": "Calibri"}
+                        }
+                    }
+                }
+                
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
Fixes the display of vertical Level 3 and horizontal Level 5 nodes by correcting their parent-child relationships and improving link generation.

The previous Vega specification incorrectly constructed the parent keys for vertical Level 3 and horizontal Level 5 nodes in the `hierarchy` data source, preventing them from being rendered. Additionally, the link generation was updated to draw connections for all nodes in the `allNodes` dataset, ensuring comprehensive visualization.

---
<a href="https://cursor.com/background-agent?bcId=bc-d45e8c73-dfc4-4068-88ff-573cb6052d81">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-d45e8c73-dfc4-4068-88ff-573cb6052d81">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

