### PR TITLE
Visualize wind power and speed with events

### DIFF
--- a/fixed_vega_spec.json
+++ b/fixed_vega_spec.json
@@ -1,0 +1,522 @@
+{
+    "$schema": "https://vega.github.io/schema/vega/v5.json",
+    "autosize": {
+        "type": "fit",
+        "contains": "padding",
+        "resize": true
+    },
+    "description": "Wind Power and Wind Speed Visualization",
+    "background": null,
+    "padding": {
+        "left": 0,
+        "right": 0,
+        "top": 30,
+        "bottom": 0
+    },
+    "signals": [
+        {
+            "name": "detailDomain"
+        },
+        {
+            "name": "brush",
+            "value": [0, 0],
+            "on": [
+                {
+                    "events": "@overview:pointerdown",
+                    "update": "[x(), x()]"
+                },
+                {
+                    "events": "[@overview:pointerdown, window:pointerup] > window:pointermove!",
+                    "update": "[brush[0], clamp(x(), 0, width)]"
+                },
+                {
+                    "events": {
+                        "signal": "delta"
+                    },
+                    "update": "clampRange([anchor[0] + delta, anchor[1] + delta], 0, width)"
+                }
+            ]
+        },
+        {
+            "name": "isDay",
+            "update": "(domain('xscaleTime')[1]-domain('xscaleTime')[0]) <= 86400000"
+        },
+        {
+            "name": "midTick",
+            "update": "(domain('xscaleTime')[0] + domain('xscaleTime')[1]) / 2"
+        },
+        {
+            "name": "anchor",
+            "value": null,
+            "on": [
+                {
+                    "events": "@brush:pointerdown",
+                    "update": "slice(brush)"
+                }
+            ]
+        },
+        {
+            "name": "xdown",
+            "value": 0,
+            "on": [
+                {
+                    "events": "@brush:pointerdown",
+                    "update": "x()"
+                }
+            ]
+        },
+        {
+            "name": "delta",
+            "value": 0,
+            "on": [
+                {
+                    "events": "[@brush:pointerdown, window:pointerup] > window:pointermove!",
+                    "update": "x() - xdown"
+                }
+            ]
+        }
+    ],
+    "data": [
+        {
+            "name": "dataset",
+            "transform": [
+                { "type": "formula", "expr": "datetime(datum.date)", "as": "date_parsed" },
+                { "type": "formula", "expr": "+datum['Mittlere Wirkleistung']", "as": "power" },
+                { "type": "formula", "expr": "+datum['Mittlere Windgeschwindigkeit']", "as": "wind_speed" },
+                { "type": "filter", "expr": "datum.power != null && datum.wind_speed != null && datum.date_parsed != null" },
+                { "type": "collect", "sort": { "field": "date_parsed" } },
+                { "type": "formula", "expr": "floor(toNumber(datum.date_parsed)/60000)", "as": "k_scada" }
+            ]
+        },
+        {
+            "name": "keys",
+            "source": "dataset",
+            "transform": [
+                { "type": "filter", "expr": "!isValid(detailDomain) || (datum.date_parsed >= detailDomain[0] && datum.date_parsed <= detailDomain[1])" },
+                { "type": "aggregate", "groupby": ["k_scada"] }
+            ]
+        },
+        {
+            "name": "events",
+            "source": "dataset",
+            "transform": [
+                { "type": "filter", "expr": "isValid(datum.date) && isValid(datum.WLOG_Code)" },
+                { "type": "formula", "expr": "datetime(datum.date)", "as": "t_event" },
+                { "type": "formula", "expr": "floor(toNumber(datum.t_event)/60000)", "as": "k_event" },
+                { "type": "lookup", "from": "keys", "key": "k_scada", "fields": ["k_event"], "as": ["hit"] },
+                { "type": "filter", "expr": "isValid(datum.hit)" },
+                { "type": "filter", "expr": "!isValid(detailDomain) || (datum.t_event >= detailDomain[0] && datum.t_event <= detailDomain[1])" }
+            ]
+        }
+    ],
+    "marks": [
+        {
+            "type": "group",
+            "name": "detail",
+            "encode": {
+                "enter": {
+                    "width": { "signal": "width" },
+                    "height": { "signal": "height * 0.7" },
+                    "x": { "value": 0 },
+                    "y": { "value": 0 }
+                }
+            },
+            "scales": [
+                {
+                    "name": "xscale",
+                    "type": "band",
+                    "range": "width",
+                    "domain": {
+                        "data": "dataset",
+                        "field": "date_parsed"
+                    },
+                    "domainRaw": { "signal": "detailDomain" },
+                    "padding": 0.1
+                },
+                {
+                    "name": "xscaleTime",
+                    "type": "time",
+                    "range": "width",
+                    "domain": {
+                        "fields": [
+                            { "data": "dataset", "field": "date_parsed" },
+                            { "data": "events", "field": "t_event" }
+                        ]
+                    },
+                    "domainRaw": { "signal": "detailDomain" }
+                },
+                {
+                    "name": "yscale",
+                    "type": "linear",
+                    "domain": {
+                        "data": "dataset",
+                        "field": "wind_speed"
+                    },
+                    "range": { "signal": "[height * 0.7, 0]" },
+                    "nice": true,
+                    "zero": true
+                },
+                {
+                    "name": "yscale2",
+                    "type": "linear",
+                    "domain": {
+                        "data": "dataset",
+                        "field": "power"
+                    },
+                    "domainMin": 0,
+                    "range": { "signal": "[height * 0.7, 0]" },
+                    "nice": true,
+                    "zero": true
+                }
+            ],
+            "axes": [
+                {
+                    "scale": "xscaleTime",
+                    "orient": "bottom",
+                    "grid": false,
+                    "labelColor": "#000000",
+                    "labelFontSize": 16,
+                    "labelFont": "Segoe UI",
+                    "labelAngle": 0,
+                    "labelPadding": 5,
+                    "values": {
+                        "signal": "(domain('xscaleTime')[1]-domain('xscaleTime')[0]) < 0.95*86400000 ? timeSequence(datetime(year(domain('xscaleTime')[0]), month(domain('xscaleTime')[0]), date(domain('xscaleTime')[0]), hours(domain('xscaleTime')[0]), 0, 0), datetime(year(domain('xscaleTime')[1]), month(domain('xscaleTime')[1]), date(domain('xscaleTime')[1]), hours(domain('xscaleTime')[1]) + 1, 0, 0), {unit:'hour', step:1}) : timeSequence(datetime(year(domain('xscaleTime')[0]), month(domain('xscaleTime')[0]), date(domain('xscaleTime')[0]), 0, 0, 0), datetime(year(domain('xscaleTime')[1]), month(domain('xscaleTime')[1]), date(domain('xscaleTime')[1]) + 1, 0, 0, 0), {unit:'day', step:1})"
+                    },
+                    "encode": {
+                        "labels": {
+                            "update": {
+                                "text": {
+                                    "signal": "(domain('xscaleTime')[1]-domain('xscaleTime')[0]) < 0.95*86400000 ? timeFormat(datum.value,'%H:%M') : (hours(datum.value)==0 ? timeFormat(datum.value,'%d.%m.') : timeFormat(datum.value,'%H:%M'))"
+                                }
+                            }
+                        }
+                    }
+                },
+                {
+                    "scale": "xscaleTime",
+                    "orient": "bottom",
+                    "grid": true,
+                    "labels": false,
+                    "ticks": false,
+                    "domain": false,
+                    "zindex": 0,
+                    "gridColor": "#e0e0e0",
+                    "gridDash": [2, 2],
+                    "gridOpacity": 1,
+                    "values": {
+                        "signal": "(domain('xscaleTime')[1]-domain('xscaleTime')[0]) < 0.95*86400000 ? timeSequence(datetime(year(domain('xscaleTime')[0]), month(domain('xscaleTime')[0]), date(domain('xscaleTime')[0]), hours(domain('xscaleTime')[0]), 0, 0), datetime(year(domain('xscaleTime')[1]), month(domain('xscaleTime')[1]), date(domain('xscaleTime')[1]), hours(domain('xscaleTime')[1]) + 1, 0, 0), {unit:'hour', step:1}) : timeSequence(datetime(year(domain('xscaleTime')[0]), month(domain('xscaleTime')[0]), date(domain('xscaleTime')[0]), 0, 0, 0), datetime(year(domain('xscaleTime')[1]), month(domain('xscaleTime')[1]), date(domain('xscaleTime')[1]) + 1, 0, 0, 0), {unit:'day', step:1})"
+                    }
+                },
+                {
+                    "scale": "yscale",
+                    "orient": "left",
+                    "grid": true,
+                    "gridColor": "#e0e0e0",
+                    "labelColor": "#000000",
+                    "labelFont": "Segoe UI",
+                    "labelFontSize": 20,
+                    "titleColor": "#000000",
+                    "title": "m/s",
+                    "titlePadding": 20,
+                    "titleFontSize": 20,
+                    "titleFont": "DIN",
+                    "titleFontWeight": "normal",
+                    "values": { "signal": "sequence(0, ceil(domain('yscale')[1]/5)*5 + 5, 5)" }
+                },
+                {
+                    "scale": "yscale2",
+                    "orient": "right",
+                    "labelColor": "#000000",
+                    "labelFont": "Segoe UI",
+                    "labelBound": false,
+                    "labelFlush": false,
+                    "labelFontSize": 20,
+                    "titleColor": "#000000",
+                    "title": "kW",
+                    "titlePadding": 20,
+                    "titleFontSize": 20,
+                    "titleFont": "DIN",
+                    "grid": false,
+                    "titleFontWeight": "normal",
+                    "values": { "signal": "sequence(0, ceil(domain('yscale2')[1]/500)*500 + 500, 500)" }
+                }
+            ],
+            "marks": [
+                {
+                    "type": "group",
+                    "encode": {
+                        "enter": {
+                            "width": { "field": { "group": "width" } },
+                            "height": { "field": { "group": "height" } },
+                            "clip": { "value": true }
+                        }
+                    },
+                    "marks": [
+                        {
+                            "type": "rect",
+                            "name": "bars",
+                            "from": { "data": "dataset" },
+                            "encode": {
+                                "enter": {
+                                    "fill": { "value": "#118DFF" },
+                                    "fillOpacity": { "value": 0.5 }
+                                },
+                                "update": {
+                                    "xc": { "scale": "xscaleTime", "field": "date_parsed" },
+                                    "width": { "value": 5 },
+                                    "y": { "scale": "yscale", "field": "wind_speed" },
+                                    "y2": { "scale": "yscale", "value": 0 },
+                                    "tooltip": {
+                                        "signal": "{'Datum': timeFormat(datum.date_parsed, '%d.%m.%Y %H:%M'), 'Windgeschwindigkeit': format(datum.wind_speed, '.1f') + ' m/s', 'Wirkleistung': format(datum.power, '.1f') + ' kW'}"
+                                    }
+                                }
+                            }
+                        },
+                        {
+                            "type": "line",
+                            "name": "line",
+                            "from": { "data": "dataset" },
+                            "encode": {
+                                "enter": {
+                                    "stroke": { "value": "#12239E" },
+                                    "strokeWidth": { "value": 3 }
+                                },
+                                "update": {
+                                    "x": { "scale": "xscaleTime", "field": "date_parsed" },
+                                    "y": { "scale": "yscale2", "field": "power" },
+                                    "defined": { "signal": "isValid(datum.power) && datum.power > 0" }
+                                }
+                            }
+                        },
+                        {
+                            "type": "symbol",
+                            "name": "errorPoints",
+                            "from": { "data": "events" },
+                            "encode": {
+                                "enter": {
+                                    "shape": { "value": "triangle-up" },
+                                    "size": { "value": 200 },
+                                    "fill": { "value": "red" },
+                                    "stroke": { "value": "darkred" },
+                                    "strokeWidth": { "value": 2 }
+                                },
+                                "update": {
+                                    "x": { "scale": "xscaleTime", "field": "t_event" },
+                                    "y": { "value": 10 },
+                                    "tooltip": {
+                                        "signal": "{'Zeit': timeFormat(datum.t_event, '%d.%m.%Y %H:%M'), 'WLOG Code': datum.WLOG_Code, 'Beschreibung': datum.description || 'Fehlercode'}"
+                                    }
+                                }
+                            }
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "type": "group",
+            "name": "overview",
+            "signals": [
+                {
+                    "name": "detailDomain",
+                    "push": "outer",
+                    "on": [
+                        {
+                            "events": { "signal": "brush" },
+                            "update": "brush[0] !== brush[1] ? invert('xOverview', brush) : null"
+                        }
+                    ]
+                }
+            ],
+            "encode": {
+                "enter": {
+                    "x": { "value": 0 },
+                    "y": { "signal": "height * 0.75" },
+                    "width": { "signal": "width" },
+                    "height": { "signal": "height * 0.15" },
+                    "fill": { "value": "transparent" }
+                }
+            },
+            "scales": [
+                {
+                    "name": "xOverview",
+                    "type": "time",
+                    "range": "width",
+                    "domain": {
+                        "data": "dataset",
+                        "field": "date_parsed"
+                    }
+                },
+                {
+                    "name": "yOverview",
+                    "type": "linear",
+                    "range": { "signal": "[height * 0.15, 0]" },
+                    "domain": {
+                        "data": "dataset",
+                        "field": "power"
+                    },
+                    "nice": true,
+                    "zero": true
+                }
+            ],
+            "axes": [
+                {
+                    "orient": "bottom",
+                    "scale": "xOverview",
+                    "labelFont": "Segoe UI",
+                    "labelFontSize": 17,
+                    "values": {
+                        "signal": "(domain('xscaleTime')[1]-domain('xscaleTime')[0]) < 0.95*86400000 ? timeSequence(datetime(year(domain('xscaleTime')[0]), month(domain('xscaleTime')[0]), date(domain('xscaleTime')[0]), hours(domain('xscaleTime')[0]), 0, 0), datetime(year(domain('xscaleTime')[1]), month(domain('xscaleTime')[1]), date(domain('xscaleTime')[1]), hours(domain('xscaleTime')[1]) + 1, 0, 0), {unit:'hour', step:1}) : timeSequence(datetime(year(domain('xscaleTime')[0]), month(domain('xscaleTime')[0]), date(domain('xscaleTime')[0]), 0, 0, 0), datetime(year(domain('xscaleTime')[1]), month(domain('xscaleTime')[1]), date(domain('xscaleTime')[1]) + 1, 0, 0, 0), {unit:'day', step:1})"
+                    },
+                    "encode": {
+                        "labels": {
+                            "update": {
+                                "text": {
+                                    "signal": "(domain('xscaleTime')[1]-domain('xscaleTime')[0]) < 0.95*86400000 ? timeFormat(datum.value,'%H:%M') : (hours(datum.value)==0 ? timeFormat(datum.value,'%d.%m.') : timeFormat(datum.value,'%H:%M'))"
+                                }
+                            }
+                        }
+                    }
+                }
+            ],
+            "marks": [
+                {
+                    "type": "area",
+                    "interactive": false,
+                    "from": { "data": "dataset" },
+                    "encode": {
+                        "update": {
+                            "x": { "scale": "xOverview", "field": "date_parsed" },
+                            "y": { "scale": "yOverview", "field": "power" },
+                            "y2": { "scale": "yOverview", "value": 0 },
+                            "fill": { "value": "#118DFF" },
+                            "fillOpacity": { "value": 0.3 }
+                        }
+                    }
+                },
+                {
+                    "type": "rect",
+                    "name": "brush",
+                    "encode": {
+                        "enter": {
+                            "y": { "value": 0 },
+                            "height": { "signal": "height * 0.15" },
+                            "fill": { "value": "#000000" },
+                            "fillOpacity": { "value": 0.2 },
+                            "cursor": { "value": "move" }
+                        },
+                        "update": {
+                            "x": { "signal": "brush[0]" },
+                            "x2": { "signal": "brush[1]" }
+                        }
+                    }
+                }
+            ]
+        },
+        {
+            "type": "group",
+            "encode": {
+                "enter": {
+                    "x": { "signal": "width / 2" },
+                    "y": { "value": 0 }
+                }
+            },
+            "marks": [
+                {
+                    "type": "group",
+                    "encode": {
+                        "enter": {
+                            "x": { "value": -300 },
+                            "y": { "value": 0 }
+                        }
+                    },
+                    "marks": [
+                        {
+                            "type": "rect",
+                            "encode": {
+                                "enter": {
+                                    "x": { "value": -10 },
+                                    "y": { "value": -5 },
+                                    "width": { "value": 15 },
+                                    "height": { "value": 10 },
+                                    "fill": { "value": "#118DFF" }
+                                }
+                            }
+                        },
+                        {
+                            "type": "text",
+                            "encode": {
+                                "enter": {
+                                    "x": { "value": 20 },
+                                    "y": { "value": 0 },
+                                    "text": { "value": "Mittlere Windgeschwindigkeit (m/s)" },
+                                    "baseline": { "value": "middle" },
+                                    "fill": { "value": "#000000" },
+                                    "fontSize": { "value": 20 },
+                                    "font": { "value": "Segoe UI" },
+                                    "fontWeight": { "value": "bold" }
+                                }
+                            }
+                        },
+                        {
+                            "type": "path",
+                            "encode": {
+                                "enter": {
+                                    "x": { "value": 380 },
+                                    "y": { "value": 0 },
+                                    "path": { "value": "M0,0 L15,0" },
+                                    "stroke": { "value": "#12239E" },
+                                    "strokeWidth": { "value": 3 }
+                                }
+                            }
+                        },
+                        {
+                            "type": "text",
+                            "encode": {
+                                "enter": {
+                                    "x": { "value": 410 },
+                                    "y": { "value": 0 },
+                                    "text": { "value": "Mittlere Wirkleistung (kW)" },
+                                    "baseline": { "value": "middle" },
+                                    "fill": { "value": "#000000" },
+                                    "fontSize": { "value": 22 },
+                                    "font": { "value": "Segoe UI" },
+                                    "fontWeight": { "value": "bold" }
+                                }
+                            }
+                        },
+                        {
+                            "type": "symbol",
+                            "encode": {
+                                "enter": {
+                                    "x": { "value": 580 },
+                                    "y": { "value": 0 },
+                                    "shape": { "value": "triangle-up" },
+                                    "size": { "value": 150 },
+                                    "fill": { "value": "red" },
+                                    "stroke": { "value": "darkred" },
+                                    "strokeWidth": { "value": 2 }
+                                }
+                            }
+                        },
+                        {
+                            "type": "text",
+                            "encode": {
+                                "enter": {
+                                    "x": { "value": 600 },
+                                    "y": { "value": 0 },
+                                    "text": { "value": "Fehlercodes" },
+                                    "baseline": { "value": "middle" },
+                                    "fill": { "value": "#000000" },
+                                    "fontSize": { "value": 20 },
+                                    "font": { "value": "Segoe UI" },
+                                    "fontWeight": { "value": "bold" }
+                                }
+                            }
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
Display error points in the Vega visualization by correcting data field usage, adjusting symbol positioning, and enhancing their visual styling for better visibility.

The original Vega specification failed to display error points because the `events` data transform used an inconsistent field (`event_time` instead of `date`), and the symbols were positioned at `y=0` on the power scale, making them indistinguishable from the axis. Additionally, their small size and subtle styling contributed to poor visibility. This PR addresses these issues by ensuring correct data processing, repositioning the symbols to the top of the chart, and applying more prominent styling (larger red triangles with a dark red border) along with a corresponding legend entry.

---
<a href="https://cursor.com/background-agent?bcId=bc-f4a60b23-35b0-4988-9476-7cd10b9315d7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-f4a60b23-35b0-4988-9476-7cd10b9315d7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

