### PR TITLE
Calculate cost carrier amounts based on conditions

### DIFF
--- a/dax_alternative.dax
+++ b/dax_alternative.dax
@@ -1,0 +1,36 @@
+[Kostenträger [Verweis]] = 
+
+//Import 
+VAR _Import = ALL('Kostenträger')
+
+VAR _Add =
+    ADDCOLUMNS (
+        _Import,
+        "AE Rechnungskosten [EUR]", [value],
+        "Weiterverechneter Betrag [EUR]",
+            VAR _CurrentID = [id]
+            VAR _CurrentYear = [year_local]
+            VAR _CurrentMonth = [month_local]
+            RETURN
+                IF (
+                    _CurrentID = "170740664",
+                    CALCULATE (
+                        SUM ( 'Kostenträger'[value] ),
+                        'Kostenträger'[id] IN { "169924262", "169923030", "168940254" },
+                        'Kostenträger'[year_local] = _CurrentYear,
+                        'Kostenträger'[month_local] = _CurrentMonth
+                    ),
+                    IF (
+                        _CurrentID = "170741466",
+                        CALCULATE (
+                            SUM ( 'Kostenträger'[value] ),
+                            'Kostenträger'[id] = "223331079",
+                            'Kostenträger'[year_local] = _CurrentYear,
+                            'Kostenträger'[month_local] = _CurrentMonth
+                        ),
+                        BLANK()
+                    )
+                )
+    )
+RETURN
+    _Add

--- a/dax_korrigiert.dax
+++ b/dax_korrigiert.dax
@@ -1,0 +1,32 @@
+[Kostenträger [Verweis]] = 
+
+//Import 
+VAR _Import = ALL('Kostenträger')
+
+VAR _Add =
+    ADDCOLUMNS (
+        _Import,
+        "AE Rechnungskosten [EUR]", [value],
+        "Weiterverechneter Betrag [EUR]",
+            IF (
+                [id] = "170740664",
+                CALCULATE (
+                    SUM ( 'Kostenträger'[value] ),
+                    'Kostenträger'[id] IN { "169924262", "169923030", "168940254" },
+                    'Kostenträger'[year_local] = EARLIER('Kostenträger'[year_local]),
+                    'Kostenträger'[month_local] = EARLIER('Kostenträger'[month_local])
+                ),
+                IF (
+                    [id] = "170741466",
+                    CALCULATE (
+                        SUM ( 'Kostenträger'[value] ),
+                        'Kostenträger'[id] = "223331079",
+                        'Kostenträger'[year_local] = EARLIER('Kostenträger'[year_local]),
+                        'Kostenträger'[month_local] = EARLIER('Kostenträger'[month_local])
+                    ),
+                    BLANK()
+                )
+            )
+    )
+RETURN
+    _Add


### PR DESCRIPTION
Add two corrected DAX formulas to resolve BLANK values caused by incorrect `SELECTEDVALUE` usage within `ADDCOLUMNS`.

The original formula used `SELECTEDVALUE` to filter `year_local` and `month_local` within `CALCULATE` inside an `ADDCOLUMNS` statement that started with `ALL('Kostenträger')`. This caused `SELECTEDVALUE` to return `BLANK` because there was no single, distinct value for year/month in the filter context. The corrected versions use `EARLIER` or explicitly defined variables to correctly reference the current row's year and month, ensuring the `CALCULATE` function operates with the intended context.

---
<a href="https://cursor.com/background-agent?bcId=bc-9f0d6316-14b2-47f0-a1cb-c176c078ab79"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-9f0d6316-14b2-47f0-a1cb-c176c078ab79"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

